### PR TITLE
De-capitalize "Lua"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The mark Natural Selection was first represented in association with video-game 
 Uses external code and libraries
 - Half Life 1 SDK LICENSE (Copyright(C) Valve Corp.)
 - FMOD 3.7.5
-- LUA 5.0 (http://lua.org)
+- Lua 5.0 (http://lua.org)
 - Particle system library by David McAllister (http://www.cs.unc.edu/techreports/00-007.pdf).
 
 Original code and design by Charlie Cleveland (charlie@unknownworlds.com, @flayra).


### PR DESCRIPTION
Lua is not an acronym: http://www.lua.org/about.html#name
