### PR TITLE
Rename COPYING.txt to COPYING.html

### DIFF
--- a/COPYING.html
+++ b/COPYING.html
@@ -1,6 +1,5 @@
 
 
-
 <!DOCTYPE html>
 <html>
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# githubog: http://ogp.me/ns/fb/githubog#">


### PR DESCRIPTION
Github happily opens this file as text, when in fact, it's not text, but instead HTML. Changing file type to allow people to clone and open in browser without difficulties.
